### PR TITLE
address app invocation issues with run.sh/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This application demonstrates how to use Streamlit with a FastAPI framework to:
 
 # Local Quickstart
 1. Start API server from root: `uvicorn src.fastAPI_app.app:app --reload`
-2. Run application from root: `venv/bin/streamlit run src/streamlit_app/app.py`
+2. Run application, ensuring the root directory is on path: `run.sh` `# export PYTHONPATH=$PYTHONPATH:$(pwd) && venv/bin/streamlit run src/streamlit_app/app.py`
 3. Use application: http://localhost:8501
  
 <b>Prerequisites</b>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Purpose: Run streamlit application, ensuring that the `src` sub-modules are in the path
+# (This emulates PyCharm's run configuration button parameter: `add content roots to PYTHONPATH`)
+
+# Find the absolute path to the project root
+PROJECT_ROOT=$(realpath "$(dirname "$0")/..")
+
+# Set PYTHONPATH to the project root, ensuring it's not added multiple times
+export PYTHONPATH=$(echo $PYTHONPATH | tr ":" "\n" | grep -v "$PROJECT_ROOT" | tr "\n" ":")$PROJECT_ROOT
+
+venv/bin/streamlit run src/streamlit_app/app.py


### PR DESCRIPTION
The routine could originally fail to run due to using relative module imports (e.g. `src.`) without the project root being present in the `PYTHONPATH`.  The new `run.sh` serves as a reminder to set this before the application is invoked!